### PR TITLE
Modal dialogs - component-style

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -81,12 +81,7 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
 
-  # HACK: fix https://www.virtualbox.org/ticket/16670
   config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
-  # config.vm.provision "shell", name: "VirtualBox bugfix", inline: <<-SHELL
-  #   ln -sf /usr/lib/x86_64-linux-gnu/VBoxGuestAdditions/mount.vboxsf /sbin/mount.vboxsf
-  #   mount -t vboxsf -o uid=1000,gid=1000 vagrant /vagrant
-  # SHELL
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     echo "Preparing local node_modules folder..."
     mkdir ~/vagrant_node_modules 2>/dev/null
@@ -115,6 +110,17 @@ Vagrant.configure("2") do |config|
     apt-get install -y -t jessie-backports openjdk-8-jre
     apt-get install -y nodejs git g++ build-essential google-chrome-stable xvfb x11vnc
   SHELL
+  # config.vm.synced_folder "../vue-bootstrap-modal", "/mnt/vue-bootstrap-modal", type: "virtualbox"
+  # config.vm.provision "shell", run: "always", inline: <<-SHELL
+  #   mkdir /mnt/vue-bootstrap-modal/node_modules 2>/dev/null
+  #   mount --bind /home/vagrant/vagrant_node_modules /vagrant/vue-bootstrap-modal_node_modules
+  #   cd /mnt/vue-bootstrap-modal
+  #   npm link
+  # SHELL
+  # config.vm.provision "shell", privileged: false, run: "always", inline: <<-SHELL
+  #   cd /vagrant 
+  #   npm link vue-bootstrap-modal
+  # SHELL
   config.vm.provision "shell", name: "Preparing app", privileged: false, run: "always", keep_color: true, inline: <<-SHELL
     cd /vagrant
 

--- a/frontend/src/components/pk-pass-editor.js
+++ b/frontend/src/components/pk-pass-editor.js
@@ -13,7 +13,8 @@ export default {
             password: item.password,
             title_error: false,
             user_error: false,
-            show_password: false
+            show_password: false,
+            current_show: this.show
         };
     },
     methods: {
@@ -36,6 +37,9 @@ export default {
         }
     },
     watch: {
+        'show'(val) {
+            this.current_show = val;
+        },
         'item.title'(val) {
             this.title_error = false;
             this.title = val;

--- a/frontend/src/components/pk-pass-editor.vue
+++ b/frontend/src/components/pk-pass-editor.vue
@@ -1,13 +1,11 @@
 <template>
     <div class="pk-pass-editor"
          :id="`pk-pass-editor-${_uid}`">
-        <modal :title="$t('editor_title')"
-               :show="show"
+        <modal :show.sync="current_show"
                @ok="ok"
-               @cancel="cancel"
-               okClass="btn btn-primary pk-btn-editor-ok"
-               :okText="$t('button_ok')"
-               :cancelText="$t('button_cancel')">
+               @cancel="cancel">
+            <span slot="title">{{ $t('editor_title') }}</span>
+
             <div class="form-group"
                  :class="{'has-error': title_error}">
                 <label class="control-label"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "nprogress": "^0.2.0",
     "toastr": "^2.1.2",
     "vue": "^2.2.4",
-    "vue-bootstrap-modal": "github:eoksni/vue-bootstrap-modal#905ce6b16992b238e8b9394976e9b2b049400cbb",
+    "vue-bootstrap-modal": "github:eoksni/vue-bootstrap-modal#53c43497bf9d0f0e3d31c1df954148379e1f122a",
     "vue-i18n": "^5.0.3",
     "vue-resource": "^1.2.1",
     "vue-router": "^2.3.0",


### PR DESCRIPTION
Refactored vue-bootstrap-modal, reduced 150 lines of code to around 20 :) 
It didn't change a lot in how it was used, but at least I got rid of that `okClass="btn btn-primary pk-btn-editor-ok"` stuff.  
Transitions are not yet working so the dialog appears instantly, I'll fix it later.
It causes some Vue warning now because of two-way sync of `show` property, but that's just BS, don't pay attention to it.

