### PR TITLE
Modal dialogs - function-style

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -113,8 +113,9 @@ Vagrant.configure("2") do |config|
   # config.vm.synced_folder "../vue-bootstrap-modal", "/mnt/vue-bootstrap-modal", type: "virtualbox"
   # config.vm.provision "shell", run: "always", inline: <<-SHELL
   #   mkdir /mnt/vue-bootstrap-modal/node_modules 2>/dev/null
-  #   mount --bind /home/vagrant/vagrant_node_modules /vagrant/vue-bootstrap-modal_node_modules
+  #   mount --bind /home/vagrant/vue-bootstrap-modal_node_modules /mnt/vue-bootstrap-modal/node_modules
   #   cd /mnt/vue-bootstrap-modal
+  #   npm install
   #   npm link
   # SHELL
   # config.vm.provision "shell", privileged: false, run: "always", inline: <<-SHELL

--- a/e2e/test/pageobjects/home.js
+++ b/e2e/test/pageobjects/home.js
@@ -3,6 +3,7 @@ const Page = require('./page.js');
 class HomePage extends Page {
     get passEntriesSelector() { return '.pk-pass-list tbody tr'; }
     /////////////////////////////////////////
+    get modalButtonOk() { return browser.$('.btn-modal-ok'); }
     get searchInput() { return browser.$('.pk-pass-filter-input'); }
     get lastPassEntry() { return browser.$('.pk-pass-list tbody tr:last-child'); }
     get passEntries() { return browser.$$(this.passEntriesSelector); }
@@ -33,7 +34,7 @@ class HomePage extends Page {
         editor.$('.pk-title-input').setValue(pass.title);
         editor.$('.pk-user-input').setValue(pass.user);
         editor.$('.pk-pass-input').setValue(pass.password);
-        editor.$('.pk-btn-editor-ok').click();
+        editor.$('.btn-modal-ok').click();
         editor.waitForVisible(undefined, true);
     }
     removePass(pass) {
@@ -53,6 +54,8 @@ class HomePage extends Page {
     }
     refreshAllPasses() {
         browser.click('.pk-btn-refresh-all-pass');
+        this.modalButtonOk.waitForEnabled();
+        this.modalButtonOk.click();
         this.waitForSuccessNotification("Items fetched.");
     }
     waitForPass(pass, ...args) {

--- a/frontend/src/components/pk-confirm.js
+++ b/frontend/src/components/pk-confirm.js
@@ -1,0 +1,13 @@
+import { Modal } from 'vue-bootstrap-modal';
+
+export default {
+    components: { Modal },
+    methods: {
+        ok() {
+            this.$emit('ok');
+        },
+        cancel() {
+            this.$emit("cancel");
+        }
+    }
+};

--- a/frontend/src/components/pk-confirm.vue
+++ b/frontend/src/components/pk-confirm.vue
@@ -1,0 +1,12 @@
+<template>
+    <modal :show="true"
+           @ok="ok"
+           @cancel="cancel">
+        <span slot="title">{{ $t('confirm_title') }}</span>
+        <span slot="button_ok">{{ $t('button_ok') }}</span>
+        <span slot="button_cancel">{{ $t('button_cancel') }}</span>
+        {{ $t('confirm_text') }}
+    </modal>
+</template>
+
+<script src="./pk-confirm.js"></script>

--- a/frontend/src/components/pk-home.js
+++ b/frontend/src/components/pk-home.js
@@ -1,6 +1,7 @@
 
 import PkPassList from './pk-pass-list.vue';
 import * as pass_store from 'src/services/pass-store.js';
+import * as modal from 'src/services/modal.js';
 
 export default {
     components: { PkPassList },
@@ -10,6 +11,16 @@ export default {
     computed: {
         num_of_entries() {
             return pass_store.get_entries().length;
+        }
+    },
+    methods: {
+        async pull() {
+            try {
+                await modal.confirm();
+            } catch (err) {
+                return;
+            }
+            this.pull_cmd.execute();
         }
     }
 };

--- a/frontend/src/components/pk-home.vue
+++ b/frontend/src/components/pk-home.vue
@@ -10,7 +10,7 @@
                 <span v-else>{{ $t('home.description.toomanypasswords') }}</span>
                 <button class="btn btn-primary pk-btn-refresh-all-pass"
                         :disabled="pull_cmd.is_executing()"
-                        @click="pull_cmd.execute()">
+                        @click="pull">
                     {{ $t('home.fetch_all_passwords') }}
                 </button>
             </p>

--- a/frontend/src/components/pk-pass-editor.js
+++ b/frontend/src/components/pk-pass-editor.js
@@ -1,10 +1,9 @@
-
 import * as PassValidator from 'src/pass-validator.js';
-import Modal from 'vue-bootstrap-modal';
+import { Modal } from 'vue-bootstrap-modal';
 
 export default {
     components: { Modal },
-    props: ['item', 'show'],
+    props: ['item'],
     data() {
         let item = this.item === undefined ? {} : this.item;
         return {
@@ -13,8 +12,7 @@ export default {
             password: item.password,
             title_error: false,
             user_error: false,
-            show_password: false,
-            current_show: this.show
+            show_password: false
         };
     },
     methods: {
@@ -29,7 +27,7 @@ export default {
             if (validation_result.title_errors.length > 0) this.title_error = true;
             if (validation_result.user_errors.length > 0) this.user_error = true;
             if (validation_result.is_valid()) {
-                this.$emit('edit', item_to_add);
+                this.$emit('ok', item_to_add);
             }
         },
         cancel() {
@@ -37,9 +35,6 @@ export default {
         }
     },
     watch: {
-        'show'(val) {
-            this.current_show = val;
-        },
         'item.title'(val) {
             this.title_error = false;
             this.title = val;

--- a/frontend/src/components/pk-pass-editor.vue
+++ b/frontend/src/components/pk-pass-editor.vue
@@ -1,10 +1,12 @@
 <template>
     <div class="pk-pass-editor"
          :id="`pk-pass-editor-${_uid}`">
-        <modal :show.sync="current_show"
+        <modal :show="true"
                @ok="ok"
                @cancel="cancel">
             <span slot="title">{{ $t('editor_title') }}</span>
+            <span slot="button_ok">{{ $t('button_ok') }}</span>
+            <span slot="button_cancel">{{ $t('button_cancel') }}</span>
 
             <div class="form-group"
                  :class="{'has-error': title_error}">

--- a/frontend/src/components/pk-pass-list.vue
+++ b/frontend/src/components/pk-pass-list.vue
@@ -1,10 +1,6 @@
 <template>
     <div class="pk-pass-list panel panel-primary"
          :id="`pk-pass-list-${_uid}`">
-        <pk-pass-editor :show="editing_item !== undefined"
-                        :item="editing_item"
-                        @cancel="cancel_edit"
-                        @edit="apply_edit"></pk-pass-editor>
         <div class="panel-heading">
             <h3 class="panel-title">{{ $t('passlist.panel_title') }}</h3>
         </div>
@@ -46,7 +42,7 @@
                                     <td>
                                         <button :disabled="!can_edit(item)"
                                                 class="btn btn-default pk-btn-pass-edit"
-                                                @click="editing_item = item"><span class="fa fa-edit"></span></button>
+                                                @click="edit(item)"><span class="fa fa-edit"></span></button>
                                         <button v-if="is_removing(item)"
                                                 class="btn btn-danger pk-btn-pass-remove"
                                                 disabled><span class="fa fa-remove fa-spin"></span></button>

--- a/frontend/src/i18ns/en.js
+++ b/frontend/src/i18ns/en.js
@@ -41,6 +41,8 @@ export default {
         itemsfetched_timeout: "Request timed-out when fetching items.",
         itemsfetched_unknown: "Couldn't fetch all items."
     },
+    confirm_text: "Are you sure?",
+    confirm_title: "Confirm",
     label_title: "Title",
     label_user: "User",
     label_password: "Password",

--- a/frontend/src/i18ns/ru.js
+++ b/frontend/src/i18ns/ru.js
@@ -41,10 +41,12 @@ export default {
         itemsfetched_timeout: "Время запроса истекло при попытке получить записи.",
         itemsfetched_unknown: "Записи не были получены."
     },
+    confirm_text: "Вы уверены?",
+    confirm_title: "Подтвердить",
     label_title: "Название",
     label_user: "Имя пользователя",
     label_password: "Пароль",
-    button_ok: "Ok",
+    button_ok: "Принять",
     button_cancel: "Отмена",
     editor_title: "Редактирование записи",
     search_placeholder: "Поиск",

--- a/frontend/src/services/modal.js
+++ b/frontend/src/services/modal.js
@@ -1,0 +1,12 @@
+import PkConfirm from 'src/components/pk-confirm.vue';
+
+import { open as openModal } from 'vue-bootstrap-modal';
+import Vue from 'vue';
+
+export function open(Component, propsData) {
+    return openModal(Vue.extend(Component), { propsData });
+}
+
+export function confirm() {
+    return open(PkConfirm);
+}

--- a/frontend/test/test-index.js
+++ b/frontend/test/test-index.js
@@ -1,4 +1,4 @@
-// require all modules ending in ".spec" from the
+// require all modules ending in ".test" from the
 // current directory and all subdirectories
 var testsContext = require.context("./", true, /.test$/);
 testsContext.keys().forEach(testsContext);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "nprogress": "^0.2.0",
     "toastr": "^2.1.2",
     "vue": "^2.2.4",
-    "vue-bootstrap-modal": "github:eoksni/vue-bootstrap-modal#53c43497bf9d0f0e3d31c1df954148379e1f122a",
+    "vue-bootstrap-modal": "github:eoksni/vue-bootstrap-modal#6412f93ee765f322e8a4ae1a54e7a8f13a2a42f3",
     "vue-i18n": "^5.0.3",
     "vue-resource": "^1.2.1",
     "vue-router": "^2.3.0",


### PR DESCRIPTION
`pk-confirm.vue` is basically an example of minimal modal dialog.
And `pk-home.js` has an example of how to use that confirmation dialog. Imagine how fucked-up it would be with purely component-based approach instead - all those `show` props laying around, and the necessity to keep track of the state when action was interrupted by confirmation dialog etc - and what if there are several actions that require confirmation!
And in case we need it, we still can use it in "component-style" way almost exactly as it used to be.